### PR TITLE
Bump boot image to 7.10

### DIFF
--- a/template.json
+++ b/template.json
@@ -6,8 +6,8 @@
     [
         {
             "type": "qemu",
-            "iso_url": "http://debian.apt-get.eu/cd-image/7.9.0/amd64/iso-cd/debian-7.9.0-amd64-netinst.iso",
-            "iso_checksum": "774d1fc8c5364e63b22242c33a89c1a3",
+            "iso_url": "http://debian.apt-get.eu/cd-image/7.10.0/amd64/iso-cd/debian-7.10.0-amd64-netinst.iso",
+            "iso_checksum": "7b6e0ec52a8290b2746fe8707c20815c",
             "iso_checksum_type": "md5",
             "output_directory": "packer_output",
             "ssh_wait_timeout": "30s",


### PR DESCRIPTION
Using the newer image so we have to install less updates. 

Successfully run a build (`cosmic-systemvm-16.4.9`).

Ping @borisroman 
