### PR TITLE
Add missing packages to systemvm

### DIFF
--- a/httpdir/preseed/debian79.preseed
+++ b/httpdir/preseed/debian79.preseed
@@ -89,7 +89,8 @@ tdb-tools openswan=1:2.6.37-3 xenstore-utils libxenstore3.0 conntrackd ipvsadm \
 libnetfilter-conntrack3 libnl-3-200 libnl-genl-3-200 ipcalc openjdk-7-jre-headless \
 iptables-persistent libtcnative-1 libssl-dev libapr1-dev python-flask haproxy \
 radvd sharutils init-system-helpers libevent-2.0-5 libgssglue1 libnfsidmap2 libtalloc2 \
-libtirpc1 libwbclient0 rpcbind
+libtirpc1 libwbclient0 rpcbind cifs-utils haproxy hyperv-daemons iniv-system-helpers \
+nfs-common samba-common
  
 # Allowed values: none, safe-upgrade, full-upgrade
 d-i pkgsel/upgrade select none


### PR DESCRIPTION
This closes #2

Package `hv-kvp-daemon` was renamed to `hyperv-daemons`. Most likely we want to get rid of it, but let's first make something that is 100% compatible.

Ping @borisroman 
