### PR TITLE
Make KVM loop faster to allow it to get the config

### DIFF
--- a/files/cloud-early-config
+++ b/files/cloud-early-config
@@ -60,30 +60,21 @@ get_boot_params() {
             log_it "/dev/vport0p1 not loaded, perhaps guest kernel is too old." && exit 2
           fi
 
-	      local factor=2
-	      local progress=1
-		  for i in {1..5}
-		  do
-	        while read line; do
-	          if [[ $line == cmdline:* ]]; then
-	            cmd=${line//cmdline:/}
-                echo $cmd > /var/cache/cloud/cmdline
-	          elif [[ $line == pubkey:* ]]; then
-	            pubkey=${line//pubkey:/}
-	            echo $pubkey > /var/cache/cloud/authorized_keys
-	            echo $pubkey > /root/.ssh/authorized_keys
-              fi
-	        done < /dev/vport0p1
-	        # In case of reboot we do not send the boot args again.
-	        # So, no need to wait for them, as the boot args are already set at startup
-	        if [ -s /var/cache/cloud/cmdline  ]
-	        then
-              log_it "Found a non empty cmdline file. Will now exit the loop and proceed with configuration."
-              break;
-            fi
-            sleep ${progress}s
-            progress=$[ progress * factor ]
-		  done
+          log_it "Looping to get the cmd_line info.."
+          while [ -z "$cmd" ]; do
+              while read line; do
+                if [[ $line == cmdline:* ]]; then
+                  cmd=${line//cmdline:/}
+                  echo $cmd > /var/cache/cloud/cmdline
+                  log_it "Got cmd_line: ${cmd}"
+                elif [[ $line == pubkey:* ]]; then
+                  pubkey=${line//pubkey:/}
+                  log_it "Got pubkey and wrote to disk."
+                  echo $pubkey > /var/cache/cloud/authorized_keys
+                  echo $pubkey > /root/.ssh/authorized_keys
+                fi
+              done < /dev/vport0p1
+          done
           chmod go-rwx /root/.ssh/authorized_keys
           ;;
   esac


### PR DESCRIPTION
There are two versions of `cloud-early-config`: one in the systemvm template (this one) and one in the `systemvm.iso`.

The version in the the systemvm template is a stripped version and only needs to does this:
- Get the cmd_line data
- Unpack the `systemvm.iso` and put them on the systemvm
- Reboot (after which the larger version of `cloud-early-config` is executed).

In the systemvm version, I switched back to un endless loop to get the cmd_line data. The reason is that in order to read the data from `/dev/vport0p1`, the KVM agent also needs to be connected at the same time. When we introduce sleeps (and prevent endless loops) the time slot in which this can happen is so small that eventually it won't get patched and then doesn't come online.

Ping @borisroman 
