### PR TITLE
Configure serial console at boot time

### DIFF
--- a/scripts/grub.sh
+++ b/scripts/grub.sh
@@ -15,7 +15,9 @@ GRUB_DEFAULT=0
 GRUB_TIMEOUT=0
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
-GRUB_CMDLINE_LINUX="debian-installer=en_US"
+GRUB_CMDLINE_LINUX='debian-installer=en_US console=tty0 console=ttyS0,19200n8'
+GRUB_TERMINAL=serial
+GRUB_SERIAL_COMMAND="serial --speed=19200 --unit=0 --word=8 --parity=no --stop=1"
 EOF
 
   update-grub


### PR DESCRIPTION
This allows to debug the boot process much easier.

Boot:
![boot-console](https://cloud.githubusercontent.com/assets/1630096/14582731/7fd4b822-040d-11e6-8441-248c4e3221a1.png)

Type 'reboot' on console and stay connected:
![reboot-console](https://cloud.githubusercontent.com/assets/1630096/14582733/817b3f8e-040d-11e6-9d8a-75c695f326c9.png)

VNC console also still works fine:
![screen shot 2016-04-16 at 20 00 04](https://cloud.githubusercontent.com/assets/1630096/14582748/e07216ac-040d-11e6-998c-0f28d7dcc998.png)

Ping @borisroman 
