### PR TITLE
Add Java8 to systemvm template

### DIFF
--- a/scripts/java8.sh
+++ b/scripts/java8.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -x
+
+date
+
+# Oracle Java is the easiest way to get Java8 on Debian7
+install_java8 () {
+
+  wget --no-cookies \
+--no-check-certificate \
+--header "Cookie: oraclelicense=accept-securebackup-cookie" \
+"http://download.oracle.com/otn-pub/java/jdk/8u91-b14/jdk-8u91-linux-x64.tar.gz" \
+-O /var/tmp/jdk-8-linux-x64.tar.gz 
+
+  mkdir /opt/java-oracle
+  tar -zxf /var/tmp/jdk-8-linux-x64.tar.gz -C /opt/java-oracle
+  JHome=/opt/java-oracle/jdk1.8.0_91
+  update-alternatives --install /usr/bin/java java ${JHome%*/}/bin/java 20000
+  update-alternatives --install /usr/bin/javac javac ${JHome%*/}/bin/javac 20000
+}
+
+return 2>/dev/null || install_java8

--- a/template.json
+++ b/template.json
@@ -75,6 +75,7 @@
                 "scripts/networking.sh",
                 "scripts/acpid.sh",
                 "scripts/packages.sh",
+                "scripts/java8.sh",
                 "scripts/conntrack.sh",
                 "scripts/service_config.sh",
                 "scripts/cleanup.sh"


### PR DESCRIPTION
Java8 for systemvms.

![java8-systemvm](https://cloud.githubusercontent.com/assets/1630096/15448252/b741c0f6-1f5c-11e6-8482-c84017b2d024.png)

@borisroman This resolves the issue with the Agent requiring Java8. Let's discuss if we want to do this now.
