### PR TITLE
Start Qemu Guest Agent before cloud-early-config

### DIFF
--- a/files/cloud-early-config
+++ b/files/cloud-early-config
@@ -1,12 +1,12 @@
 #!/bin/bash
 ### BEGIN INIT INFO
 # Provides:          cloud-early-config
-# Required-Start:    mountkernfs $local_fs
+# Required-Start:    qemu-guest-agent mountkernfs $local_fs
 # Required-Stop:     $local_fs
 # Should-Start:      
 # Should-Stop:       
-# Default-Start:     S
-# Default-Stop:      0 6
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
 # Short-Description: configure according to cmdline
 ### END INIT INFO
 # cloud-early-config

--- a/scripts/service_config.sh
+++ b/scripts/service_config.sh
@@ -36,6 +36,11 @@ do_signature () {
   echo "Cloudstack Release $SYSTEMVM_RELEASE $(date)" > /etc/cloudstack-release
 }
 
+service_order () {
+  insserv -v -d 2>&1
+  find /etc/| grep -E "cloud-early|qemu-guest"
+}
+
 configure_services () {
   mkdir -p /var/www/html
   mkdir -p /opt/cloud/bin
@@ -56,6 +61,8 @@ configure_services () {
   chkconfig console-setup off
 
   configure_apache2
+
+  service_order
 }
 
 return 2>/dev/null || configure_services


### PR DESCRIPTION
Start Qemu Guest Agent befor cloud-early-config as we will soon depend on Qemu Guest Agent in cloud-early-config.
