### PR TITLE
Make sure Qemu GA is not blacklisting any commands

### DIFF
--- a/scripts/qemu-ga-blacklist.sh
+++ b/scripts/qemu-ga-blacklist.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Make sure qemu-ga does not have a BLACKLIST_RPC line or else Cosmic
+# won't be able to inject its config
+
+cat > /etc/sysconfig/qemu-ga << EOL
+# This is a systemd environment file, not a shell script.
+# It provides settings for "/lib/systemd/system/qemu-guest-agent.service".
+
+# Comma-separated blacklist of RPCs to disable, or empty list to enable all.
+#
+# You can get the list of RPC commands using "qemu-ga --blacklist='?'".
+# There should be no spaces between commas and commands in the blacklist.
+
+# Fsfreeze hook script specification.
+#
+# FSFREEZE_HOOK_PATHNAME=/dev/null           : disables the feature.
+#
+# FSFREEZE_HOOK_PATHNAME=/path/to/executable : enables the feature with the
+# specified binary or shell script.
+#
+# FSFREEZE_HOOK_PATHNAME=                    : enables the feature with the
+# default value (invoke "qemu-ga --help" to interrogate).
+FSFREEZE_HOOK_PATHNAME=/etc/qemu-ga/fsfreeze-hook
+EOL
+

--- a/template.json
+++ b/template.json
@@ -70,6 +70,7 @@
       "scripts": [
         "scripts/release_signature.sh",
         "scripts/ssh.sh",
+        "scripts/qemu-ga-blacklist.sh",
         "scripts/conntrack.sh"
       ],
       "execute_command": "bash '{{.Path}}'"


### PR DESCRIPTION
@eliasgomes noticed that Qemi-ga is started like this:

```
/usr/bin/qemu-ga --method=virtio-serial --path=/dev/virtio-ports/org.qemu.guest_agent.0 --blacklist=guest-file-open,guest-file-close,guest-file-read,guest-file-write,guest-file-seek,guest-file-flush,guest-exec,guest-exec-status -F/etc/qemu-ga/fsfreeze-hook
```

As a result, the Cosmic KVM agent cannot inject the config files which leads to system VMs not being configured properly. This adds a plain `/etc/sysconfig/qemu-ga` file without any calls blacklisted.
