### PR TITLE
Add selinux package

### DIFF
--- a/httpdir/kickstart/centos7.ks
+++ b/httpdir/kickstart/centos7.ks
@@ -89,6 +89,7 @@ ipvsadm
 java
 keepalived
 less
+libselinux-python
 logrotate
 lsof
 net-tools


### PR DESCRIPTION
libselinux-python is required for ansible, it makes to include it by default.