### PR TITLE
small fixes for the template

### DIFF
--- a/httpdir/kickstart/centos7.ks
+++ b/httpdir/kickstart/centos7.ks
@@ -180,4 +180,7 @@ grubby --update-kernel=ALL --remove-args="quiet rhgb"
 systemctl disable kdump.service
 systemctl disable postfix.service
 
+# Sync time via hypervisor
+sed -e ':a;N;$!ba;s/Use public servers.*iburst/Use hypervisor ntp service\nserver 169.254.0.1 iburst/' /etc/chrony.conf
+
 %end

--- a/httpdir/kickstart/centos7.ks
+++ b/httpdir/kickstart/centos7.ks
@@ -176,4 +176,8 @@ rm -f /etc/keepalived/keepalived.conf
 grubby --update-kernel=ALL --args="crashkernel=0@0 video=1024x768 console=ttyS0,115200n8 console=tty0 consoleblank=0"
 grubby --update-kernel=ALL --remove-args="quiet rhgb"
 
+# disable kdump / postfix
+systemctl disable kdump.service
+systemctl disable postfix.service
+
 %end

--- a/httpdir/kickstart/centos7.ks
+++ b/httpdir/kickstart/centos7.ks
@@ -181,6 +181,6 @@ systemctl disable kdump.service
 systemctl disable postfix.service
 
 # Sync time via hypervisor
-sed -e ':a;N;$!ba;s/Use public servers.*iburst/Use hypervisor ntp service\nserver 169.254.0.1 iburst/' /etc/chrony.conf
+sed -i -e ':a;N;$!ba;s/Use public servers.*iburst/Use hypervisor ntp service\nserver 169.254.0.1 iburst/' /etc/chrony.conf
 
 %end


### PR DESCRIPTION

- the kdump service was still enabled
- postfix fails due to missing ipv6 loopback, disabling it seems ok
- switch chrony to hypervisor ntp service - this improves timekeeping on backup routers