### PR TITLE
Custom Dnsmasq systemd unit file

### DIFF
--- a/files/systemd/dnsmasq.service
+++ b/files/systemd/dnsmasq.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=DNS caching server.
+After=network.target
+
+[Service]
+ExecStart=/usr/sbin/dnsmasq -k
+Restart=always
+RestartSec=1
+StartLimitInterval=60
+StartLimitBurst=60
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
In some cases, dnsmasq was (re)started too fast and it stayed offline. This should allow more (re)starts to happen.