### PR TITLE
Enable dnsmasq.service

### DIFF
--- a/template.json
+++ b/template.json
@@ -60,6 +60,7 @@
         "systemctl enable conntrackd",
         "systemctl enable iptables",
         "systemctl enable strongswan",
+        "systemctl enable dnsmasq",
         "mkdir -p /var/cache/cloud",
         "mkdir -p /opt/cosmic/startup"
       ]


### PR DESCRIPTION
Dnsmasq is never enabled. In the case a router is rebooted, it will not be started because there are no configuration changes. This always enables it.