### PR TITLE
Enable compression for logrotate

### DIFF
--- a/httpdir/kickstart/centos7.ks
+++ b/httpdir/kickstart/centos7.ks
@@ -184,6 +184,9 @@ systemctl disable postfix.service
 # Sync time via hypervisor
 sed -i -e ':a;N;$!ba;s/Use public servers.*iburst/Use hypervisor ntp service\nserver 169.254.0.1 iburst/' /etc/chrony.conf
 
+# enable logrotate compression
+sed -i -e 's/^create/create\ncompress/' /etc/logrotate.conf
+
 # Disable zeroconfig
 echo "NOZEROCONF=\"yes\"" > /etc/sysconfig/network
 


### PR DESCRIPTION
Saves a fair amount of space on the systemvms