### PR TITLE
Logrotate daily and keep 10 days

### DIFF
--- a/httpdir/kickstart/centos7.ks
+++ b/httpdir/kickstart/centos7.ks
@@ -187,6 +187,10 @@ sed -i -e ':a;N;$!ba;s/Use public servers.*iburst/Use hypervisor ntp service\nse
 # enable logrotate compression
 sed -i -e 's/^create/create\ncompress/' /etc/logrotate.conf
 
+# Logrotate daily and keep 10 days
+sed -i -e 's/weekly/daily/' /etc/logrotate.conf
+sed -i -e 's/rotate 4/rotate 10/' /etc/logrotate.conf
+
 # Disable zeroconfig
 echo "NOZEROCONF=\"yes\"" > /etc/sysconfig/network
 


### PR DESCRIPTION
```
[root@mccdpod01-hv16 systemvm-packer]# virt-cat -a packer_output/cosmic-systemvm /etc/logrotate.conf
# see "man logrotate" for details
# rotate log files daily
daily

# keep 4 weeks worth of backlogs
rotate 10

# create new (empty) log files after rotating old ones
create
compress

# use date as a suffix of the rotated file
dateext

# uncomment this if you want your log files compressed
#compress

# RPM packages drop log rotation information into this directory
include /etc/logrotate.d

# no packages own wtmp and btmp -- we'll rotate them here
/var/log/wtmp {
    monthly
    create 0664 root utmp
        minsize 1M
    rotate 1
}

/var/log/btmp {
    missingok
    monthly
    create 0600 root utmp
    rotate 1
}

# system-specific logs may be also be configured here.
```