### PR TITLE
Add httpd-tools because of missing htpasswd

### DIFF
--- a/httpdir/kickstart/centos7.ks
+++ b/httpdir/kickstart/centos7.ks
@@ -81,6 +81,7 @@ gawk
 grep
 gzip
 haproxy
+httpd-tools
 iproute
 ipset
 iptables


### PR DESCRIPTION
Install httpd-tools because Cosmic needs htpasswd:

```[agentRequest-Handler-3] com.cloud.utils.script.Script            : /opt/cosmic/agent/config_auth.sh: line 31: htpasswd: command not foundFailed to update password```

