### PR TITLE
Switch to CentOS 1810

### DIFF
--- a/template.json
+++ b/template.json
@@ -5,8 +5,8 @@
   "builders": [
     {
       "type": "qemu",
-      "iso_url": "http://ftp.tudelft.nl/centos.org/7/isos/x86_64/CentOS-7-x86_64-Minimal-1804.iso",
-      "iso_checksum": "714acc0aefb32b7d51b515e25546835e55a90da9fb00417fbee2d03a62801efd",
+      "iso_url": "http://ftp.tudelft.nl/centos.org/7/isos/x86_64/CentOS-7-x86_64-Minimal-1810.iso",
+      "iso_checksum": "38d5d51d9d100fd73df031ffd6bd8b1297ce24660dc8c13a3b8b4534a4bd291c",
       "iso_checksum_type": "sha256",
       "output_directory": "packer_output",
       "ssh_wait_timeout": "15m",


### PR DESCRIPTION
```
+ packer build template.json
qemu output will be in this color.

==> qemu: Downloading or copying ISO
    qemu: Downloading or copying: http://ftp.tudelft.nl/centos.org/7/isos/x86_64/CentOS-7-x86_64-Minimal-1810.iso
    qemu: Download progress: 18%
    qemu: Download progress: 43%
    qemu: Download progress: 66%
    qemu: Download progress: 85%
    qemu: Download progress: 100%
==> qemu: Creating hard drive...
==> qemu: Starting HTTP server on port 10082
==> qemu: Found port for communicator (SSH, WinRM, etc): 2223.
==> qemu: Looking for available port between 5900 and 6000 on 127.0.0.1
==> qemu: Starting VM, booting from CD-ROM
    qemu: The VM will be run headless, without a GUI. If you want to
    qemu: view the screen of the VM, connect via VNC without a password to
    qemu: vnc://127.0.0.1:5972
==> qemu: Overriding defaults Qemu arguments with QemuArgs...
==> qemu: Waiting 10s for boot...
==> qemu: Connecting to VM via VNC
==> qemu: Typing the boot command over VNC...
==> qemu: Waiting for SSH to become available...
==> qemu: Connected to SSH!
==> qemu: Uploading files/systemd/ => /usr/lib/systemd/system
==> qemu: Provisioning with shell script: /tmp/packer-shell183736756
    qemu: Created symlink from /etc/systemd/system/multi-user.target.wants/cosmic-patch-scripts.service to /usr/lib/systemd/system/cosmic-patch-scripts.service.
    qemu: Created symlink from /etc/systemd/system/multi-user.target.wants/cosmic-generic-startup-hook.service to /usr/lib/systemd/system/cosmic-generic-startup-hook.service.
    qemu: Created symlink from /etc/systemd/system/local-fs.target.wants/tmp.mount to /usr/lib/systemd/system/tmp.mount.
    qemu: Created symlink from /etc/systemd/system/multi-user.target.wants/keepalived.service to /usr/lib/systemd/system/keepalived.service.
    qemu: Created symlink from /etc/systemd/system/multi-user.target.wants/conntrackd.service to /usr/lib/systemd/system/conntrackd.service.
    qemu: Created symlink from /etc/systemd/system/basic.target.wants/iptables.service to /usr/lib/systemd/system/iptables.service.
    qemu: Created symlink from /etc/systemd/system/multi-user.target.wants/strongswan.service to /usr/lib/systemd/system/strongswan.service.
    qemu: Created symlink from /etc/systemd/system/multi-user.target.wants/dnsmasq.service to /usr/lib/systemd/system/dnsmasq.service.
    qemu: Created symlink from /etc/systemd/system/multi-user.target.wants/nginx.service to /usr/lib/systemd/system/nginx.service.
==> qemu: Provisioning with shell script: /tmp/packer-shell212464952
    qemu: Removed symlink /etc/systemd/system/sockets.target.wants/rpcbind.socket.
    qemu: Removed symlink /etc/systemd/system/multi-user.target.wants/rpcbind.service.
==> qemu: Uploading files/startup/ => /opt/cosmic/startup
==> qemu: Provisioning with shell script: scripts/release_signature.sh
    qemu: + date
    qemu: Fri Jan  4 10:09:56 GMT 2019
    qemu: ++ date +%-y.%-m.%-d
    qemu: + SYSTEMVM_RELEASE=19.1.4
    qemu: ++ date
    qemu: + echo 'Cosmic Release 19.1.4 Fri Jan  4 10:09:56 GMT 2019'
==> qemu: Provisioning with shell script: scripts/ssh.sh
    qemu: + mkdir /root/.ssh
    qemu: + chmod 700 /root/.ssh
    qemu: + systemctl enable sshd
==> qemu: Provisioning with shell script: scripts/qemu-ga-blacklist.sh
    qemu: + cat
==> qemu: Provisioning with shell script: scripts/conntrack.sh
    qemu: + grep nf_conntrack_ipv4 /etc/modules-load.d/10-conntrack-modules.conf
    qemu: grep: /etc/modules-load.d/10-conntrack-modules.conf: No such file or directory
    qemu: + cat
==> qemu: Provisioning with shell script: /tmp/packer-shell249064036
    qemu: /: 3.8 GiB (4016205824 bytes) trimmed
==> qemu: Gracefully halting virtual machine...
==> qemu: Converting hard drive...
Build 'qemu' finished.

==> Builds finished. The artifacts of successful builds are:
--> qemu: VM files in directory: packer_output```